### PR TITLE
Backport QRunnable from lambda to Qt5.12

### DIFF
--- a/src/libclient/document.cpp
+++ b/src/libclient/document.cpp
@@ -31,6 +31,7 @@
 #include "export/canvassaverrunnable.h"
 #include "tools/toolcontroller.h"
 #include "utils/images.h"
+#include "../libshared/util/functionrunnable.h"
 
 #include <QGuiApplication>
 #include <QSettings>
@@ -40,6 +41,7 @@
 #include <QThreadPool>
 #include <QPainter>
 #include <QtEndian>
+#include <QRunnable>
 
 Document::Document(QObject *parent)
 	: QObject(parent),
@@ -702,9 +704,11 @@ void Document::snapshotNeeded()
 	// (We) requested a session reset and the server is now ready for it.
 	if(m_canvas) {
 		if(m_resetstate.isEmpty()) {
-			QThreadPool::globalInstance()->start([this](){
+			// FunctionRunnable has autoDelete enabled
+			auto runnable = new utils::FunctionRunnable([this](){
 				generateJustInTimeSnapshot();
 			});
+			QThreadPool::globalInstance()->start(runnable);
 		} else {
 			sendResetSnapshot();
 		}

--- a/src/libshared/CMakeLists.txt
+++ b/src/libshared/CMakeLists.txt
@@ -19,6 +19,7 @@ set(libshared_sources
 	record/reader.cpp
 	record/writer.cpp
 	util/filename.cpp
+	util/functionrunnable.cpp
 	util/networkaccess.cpp
 	util/passwordhash.cpp
 	util/paths.cpp

--- a/src/libshared/util/functionrunnable.cpp
+++ b/src/libshared/util/functionrunnable.cpp
@@ -1,0 +1,36 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2023-2023
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#include "functionrunnable.h"
+
+namespace utils {
+
+/*
+    Code backported from Qt5.15 to be used in Qt5.12.
+*/
+FunctionRunnable::FunctionRunnable(std::function<void()> functionToRun) : m_functionToRun(std::move(functionToRun)) {
+    setAutoDelete(true);
+}
+
+void FunctionRunnable::run() {
+    m_functionToRun();
+}
+
+}

--- a/src/libshared/util/functionrunnable.h
+++ b/src/libshared/util/functionrunnable.h
@@ -1,0 +1,41 @@
+/*
+   Drawpile - a collaborative drawing program.
+
+   Copyright (C) 2023-2023
+
+   Drawpile is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Drawpile is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Drawpile.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef FUNCTIONRUNNABLE_H
+#define FUNCTIONRUNNABLE_H
+
+#include <QRunnable>
+#include <functional>
+
+namespace utils {
+
+/*
+    Code backported from Qt5.15 to be used in Qt5.12.
+*/
+class FunctionRunnable : public QRunnable
+{
+    std::function<void()> m_functionToRun;
+public:
+    FunctionRunnable(std::function<void()> functionToRun);
+    void run();
+};
+
+}
+
+#endif


### PR DESCRIPTION
Qt5.15 added an overload to call QThreadPool.start with an std::function.